### PR TITLE
Add taints and labels to ASG

### DIFF
--- a/modules/node_groups/locals.tf
+++ b/modules/node_groups/locals.tf
@@ -11,8 +11,28 @@ locals {
       max_capacity            = var.workers_group_defaults["asg_max_size"]
       min_capacity            = var.workers_group_defaults["asg_min_size"]
       subnets                 = var.workers_group_defaults["subnets"]
+      labels = merge(
+        lookup(var.node_groups_defaults, "k8s_labels", {}),
+        lookup(var.node_groups[k], "k8s_labels", {})
+      )
+      taints = concat(
+        lookup(var.node_groups_defaults, "k8s_taints", []),
+        lookup(var.node_groups[k], "k8s_taints", [])
+      )
     },
     var.node_groups_defaults,
     v,
   ) if var.create_eks }
+
+  nodegroup_labels = { for obj in flatten([
+    for name, attr in local.node_groups_expanded : [
+      for label, value in attr.labels : { pool = name, key = label, value = value }
+    ]
+  ]) : format("%s/%s", obj.pool, obj.key) => obj }
+
+  nodegroup_taints = { for obj in flatten([
+    for name, attr in local.node_groups_expanded : [
+      for taint in attr.taints : { pool = name, key = taint.key, value = taint.value, effect = taint.effect }
+    ]
+  ]) : format("%s/%s", obj.pool, obj.key) => obj }
 }


### PR DESCRIPTION
This PR will set labels and taints from the keys `k8s_labels` and `k8s_taints` on the managed node groups, as well as propagate them to the ASGs with the necessary formatting for the cluster autoscaler.